### PR TITLE
Fribbs JSON Parsing + IMDB 

### DIFF
--- a/Jellyfin.Plugin.AnimeMultiSource/Providers/AnimeListMapper.cs
+++ b/Jellyfin.Plugin.AnimeMultiSource/Providers/AnimeListMapper.cs
@@ -52,9 +52,10 @@ namespace Jellyfin.Plugin.AnimeMultiSource.Providers
                     ?? new Dictionary<string, AnimeMapping>();
 
                 _mappingsByImdb = mappings?
-                    .Where(x => !string.IsNullOrEmpty(x.imdb_id))
-                    .GroupBy(x => x.imdb_id!)
-                    .ToDictionary(g => g.Key, g => SelectPreferredMapping(g))
+                    .SelectMany(m => m.imdb_id.Select(id => (id, m)))
+                    .Where(x => !string.IsNullOrEmpty(x.id))
+                    .GroupBy(x => x.id)
+                    .ToDictionary(g => g.Key, g => SelectPreferredMapping(g.Select(x => x.m)))
                     ?? new Dictionary<string, AnimeMapping>();
 
                 _mappingsByAniList = mappings?
@@ -134,7 +135,7 @@ namespace Jellyfin.Plugin.AnimeMultiSource.Providers
         [JsonIgnore]
         public long? TvdbId => tvdb_id ?? thetvdb_id;
 
-        public string? imdb_id { get; set; }
+        public string[] imdb_id { get; set; } = [];
 
         [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)]
         public long? anisearch_id { get; set; }

--- a/Jellyfin.Plugin.AnimeMultiSource/Providers/AnimeMultiSourceService.cs
+++ b/Jellyfin.Plugin.AnimeMultiSource/Providers/AnimeMultiSourceService.cs
@@ -98,7 +98,7 @@ namespace Jellyfin.Plugin.AnimeMultiSource.Providers
             new AnimeMapping
             {
                 tvdb_id = 442363,
-                imdb_id = "tt33054444",
+                imdb_id = ["tt33054444"],
                 anilist_id = 152184,
                 mal_id = 57192,
                 type = "ONA"
@@ -169,7 +169,9 @@ namespace Jellyfin.Plugin.AnimeMultiSource.Providers
 
             if (mapping == null && !string.IsNullOrEmpty(plexMatchData.ImdbId))
             {
-                mapping = _manualMappings.FirstOrDefault(m => string.Equals(m.imdb_id, plexMatchData.ImdbId, StringComparison.OrdinalIgnoreCase))
+                mapping = _manualMappings.FirstOrDefault(m =>
+                    m.imdb_id.Any(id =>
+                        string.Equals(id, plexMatchData.ImdbId, StringComparison.OrdinalIgnoreCase)))
                     ?? _animeListMapper.GetMappingByImdbId(plexMatchData.ImdbId);
             }
 


### PR DESCRIPTION
Disclosure upfront: Changes were LLM assisted, my C# is pretty rusty. Feel free to discard/re-implement as you see fit :slightly_smiling_face:  

The Fribbs downloads were failing to parse the imdb_id formats in the new list format.

```text
[2026-06-20 10:24:28.062 +00:00] [ERR] [39] Jellyfin.Plugin.AnimeMultiSource.Providers.AnimeMultiSourceProvider: Failed to load anime lists
System.Text.Json.JsonException: The JSON value could not be converted to System.String. Path: $[0].imdb_id | LineNumber: 8 | BytePositionInLine: 15.
 ---> System.InvalidOperationException: Cannot get the value of a token type 'StartArray' as a string.
   at System.Text.Json.ThrowHelper.ThrowInvalidOperationException_ExpectedString(JsonTokenType tokenType)
   at System.Text.Json.Utf8JsonReader.GetString()
   at System.Text.Json.Serialization.Metadata.JsonPropertyInfo`1.ReadJsonAndSetMember(Object obj, ReadStack& state, Utf8JsonReader& reader)
   at System.Text.Json.Serialization.Converters.ObjectDefaultConverter`1.OnTryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value)
   at System.Text.Json.Serialization.JsonConverter`1.TryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value, Boolean& isPopulatedValue)
   at System.Text.Json.Serialization.JsonCollectionConverter`2.OnTryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, TCollection& value)
   at System.Text.Json.Serialization.JsonConverter`1.TryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value, Boolean& isPopulatedValue)
   at System.Text.Json.Serialization.JsonConverter`1.ReadCore(Utf8JsonReader& reader, T& value, JsonSerializerOptions options, ReadStack& state)
   --- End of inner exception stack trace ---
   at System.Text.Json.ThrowHelper.ReThrowWithPath(ReadStack& state, Utf8JsonReader& reader, Exception ex)
   at System.Text.Json.Serialization.JsonConverter`1.ReadCore(Utf8JsonReader& reader, T& value, JsonSerializerOptions options, ReadStack& state)
   at System.Text.Json.JsonSerializer.ReadFromSpan[TValue](ReadOnlySpan`1 json, JsonTypeInfo`1 jsonTypeInfo)
   at Jellyfin.Plugin.AnimeMultiSource.Providers.AnimeListMapper.LoadAnimeListsAsync()
   at Jellyfin.Plugin.AnimeMultiSource.Providers.AnimeMultiSourceService.GetMetadataForSeries(SeriesInfo info, PluginConfiguration config)
[2026-06-20 10:24:28.063 +00:00] [ERR] [39] Jellyfin.Plugin.AnimeMultiSource.Providers.AnimeMultiSourceProvider: Error in call #2 for "Sailor Moon"
System.Text.Json.JsonException: The JSON value could not be converted to System.String. Path: $[0].imdb_id | LineNumber: 8 | BytePositionInLine: 15.
 ---> System.InvalidOperationException: Cannot get the value of a token type 'StartArray' as a string.
   at System.Text.Json.ThrowHelper.ThrowInvalidOperationException_ExpectedString(JsonTokenType tokenType)
   at System.Text.Json.Utf8JsonReader.GetString()
   at System.Text.Json.Serialization.Metadata.JsonPropertyInfo`1.ReadJsonAndSetMember(Object obj, ReadStack& state, Utf8JsonReader& reader)
   at System.Text.Json.Serialization.Converters.ObjectDefaultConverter`1.OnTryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value)
   at System.Text.Json.Serialization.JsonConverter`1.TryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value, Boolean& isPopulatedValue)
   at System.Text.Json.Serialization.JsonCollectionConverter`2.OnTryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, TCollection& value)
   at System.Text.Json.Serialization.JsonConverter`1.TryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value, Boolean& isPopulatedValue)
   at System.Text.Json.Serialization.JsonConverter`1.ReadCore(Utf8JsonReader& reader, T& value, JsonSerializerOptions options, ReadStack& state)
   --- End of inner exception stack trace ---
   at System.Text.Json.ThrowHelper.ReThrowWithPath(ReadStack& state, Utf8JsonReader& reader, Exception ex)
   at System.Text.Json.Serialization.JsonConverter`1.ReadCore(Utf8JsonReader& reader, T& value, JsonSerializerOptions options, ReadStack& state)
   at System.Text.Json.JsonSerializer.ReadFromSpan[TValue](ReadOnlySpan`1 json, JsonTypeInfo`1 jsonTypeInfo)
   at Jellyfin.Plugin.AnimeMultiSource.Providers.AnimeListMapper.LoadAnimeListsAsync()
   at Jellyfin.Plugin.AnimeMultiSource.Providers.AnimeMultiSourceService.GetMetadataForSeries(SeriesInfo info, PluginConfiguration config)
   at Jellyfin.Plugin.AnimeMultiSource.Providers.AnimeMultiSourceProvider.GetMetadata(SeriesInfo info, CancellationToken cancellationToken)
```

This aligns the list mapper to the new Fribbs format.

```json
{
  "type" : "TV",
  "anidb_id" : 235,
  "anilist_id" : 530,
  "animecountdown_id" : 38425,
  "animenewsnetwork_id" : 363,
  "anime-planet_id" : "sailor-moon",
  "anisearch_id" : 2469,
  "imdb_id" : [ "tt0103369" ],
  "kitsu_id" : 489,
  "livechart_id" : 3884,
  "mal_id" : 530,
  "simkl_id" : 38425,
  "themoviedb_id" : {
    "tv" : 3570
  },
  "tvdb_id" : 78500,
  "season" : {
    "tvdb" : 1,
    "tmdb" : 1
  }
}
```