### PR TITLE
Add support for Romaji original titles

### DIFF
--- a/Jellyfin.Plugin.AnimeMultiSource/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.AnimeMultiSource/Configuration/PluginConfiguration.cs
@@ -12,7 +12,8 @@ namespace Jellyfin.Plugin.AnimeMultiSource.Configuration
     public enum OriginalTitleFieldType
     {
         Title,
-        TitleJapanese
+        TitleJapanese,
+        TitleRomaji
     }
 
     public enum DataSourceType

--- a/Jellyfin.Plugin.AnimeMultiSource/Configuration/configPage.html
+++ b/Jellyfin.Plugin.AnimeMultiSource/Configuration/configPage.html
@@ -37,6 +37,7 @@
                         <label class="selectLabel" for="originalTitleField">Original Title Field</label>
                         <select is="emby-select" id="originalTitleField" name="originalTitleField" class="emby-select-withcolor emby-select">
                             <option value="Title">Title</option>
+                            <option value="TitleRomaji">Romaji Title</option>
                             <option value="TitleJapanese">Japanese Title</option>
                         </select>
                     </div>

--- a/Jellyfin.Plugin.AnimeMultiSource/Providers/AnimeMultiSourceService.cs
+++ b/Jellyfin.Plugin.AnimeMultiSource/Providers/AnimeMultiSourceService.cs
@@ -720,6 +720,7 @@ namespace Jellyfin.Plugin.AnimeMultiSource.Providers
             return field switch
             {
                 Configuration.OriginalTitleFieldType.Title => jikanData.Title,
+                Configuration.OriginalTitleFieldType.TitleRomaji => jikanData.Title,
                 Configuration.OriginalTitleFieldType.TitleJapanese => jikanData.TitleJapanese,
                 _ => jikanData.TitleJapanese
             };
@@ -732,6 +733,7 @@ namespace Jellyfin.Plugin.AnimeMultiSource.Providers
             return field switch
             {
                 Configuration.OriginalTitleFieldType.Title => aniListData.Title.Romaji,
+                Configuration.OriginalTitleFieldType.TitleRomaji => aniListData.Title.Romaji,
                 Configuration.OriginalTitleFieldType.TitleJapanese => aniListData.Title.Native,
                 _ => aniListData.Title.Native
             };


### PR DESCRIPTION
Resolves #8

Adds a **Romaji Title** option to the **Original Title Field** setting.

> Note: No testing was done as this was done in an environment without dotnet.